### PR TITLE
[FEAT&FIX] 미리보기 페이지에서 서명하기, 미리보기 페이지 문서 반응형

### DIFF
--- a/src/Pages/PreviewTaskPage.js
+++ b/src/Pages/PreviewTaskPage.js
@@ -7,6 +7,7 @@ import CompleteModal from "../components/AllocatePage/CompleteModal";
 import ButtonBase from "../components/ButtonBase";
 import RejectModal from "../components/ListPage/RejectModal";
 import PDFViewer from "../components/SignPage/PDFViewer";
+import SignatureOverlay from "../components/SignPage/SignatureOverlay";
 import SignaturePopup from "../components/SignPage/SignaturePopup";
 import { signingState } from "../recoil/atom/signingState";
 import ApiService from "../utils/ApiService";
@@ -19,6 +20,7 @@ const PreviewPage = () => {
   const [showRejectModal, setShowRejectModal] = useState(false);
   const [loading, setLoading] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
+  const [pdfScale, setPdfScale] = useState(1);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -120,34 +122,8 @@ const PreviewPage = () => {
         <PDFWrapper>
           {signing.fileUrl && signing.signatureFields ? (
             <DocumentContainer>
-              <PDFViewer pdfUrl={signing.fileUrl} setCurrentPage={setCurrentPage} />
-              {signing.signatureFields
-                .filter((field) => field.position.pageNumber === currentPage)
-                .map((field, index) => (
-                  <div
-                    key={index}
-                    style={{
-                      position: "absolute",
-                      left: field.position.x,
-                      top: field.position.y,
-                      width: field.width,
-                      height: field.height,
-                      border: field.image ? "none" : "2px dashed black",
-                      backgroundColor: field.image ? "transparent" : "#f8f9fa50",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    {field.image && (
-                      <img
-                        src={field.image}
-                        alt="서명"
-                        style={{ width: "100%", height: "100%", objectFit: "contain", border: "2px solid black" }}
-                      />
-                    )}
-                  </div>
-              ))}
+              <PDFViewer pdfUrl={signing.fileUrl} setCurrentPage={setCurrentPage} onScaleChange={setPdfScale} />
+              <SignatureOverlay currentPage={currentPage} scale={pdfScale} />
             </DocumentContainer>
           ) : (
             <LoadingMessage>문서 및 서명 정보를 불러오는 중...</LoadingMessage>
@@ -241,9 +217,10 @@ const Value = styled.span`
 `;
 
 const DocumentContainer = styled.div`
-  max-width: 800px;
+  max-width: 70vw;
   background-color: #f5f5f5;
   position: relative;
+  width: 100%;
 `;
 
 const LoadingMessage = styled.p`

--- a/src/Pages/PreviewTaskPage.js
+++ b/src/Pages/PreviewTaskPage.js
@@ -1,24 +1,27 @@
-// PreviewPage.js
+// PreviewTaskPage.js
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
+import CompleteModal from "../components/AllocatePage/CompleteModal";
 import ButtonBase from "../components/ButtonBase";
 import RejectModal from "../components/ListPage/RejectModal";
-import SignatureMarker from "../components/PreviewPage/SignatureMarker";
 import PDFViewer from "../components/SignPage/PDFViewer";
+import SignaturePopup from "../components/SignPage/SignaturePopup";
 import { signingState } from "../recoil/atom/signingState";
 import ApiService from "../utils/ApiService";
 
 const PreviewPage = () => {
-  const [signing] = useRecoilState(signingState);
-  const [currentPage, setCurrentPage] = React.useState(1);
-  const [showModal, setShowModal] = useState(false);
+  const [signing, setSigning] = useRecoilState(signingState);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [showPopup, setShowPopup] = useState(false);
+  const [showCompleteModal, setShowCompleteModal] = useState(false);
+  const [showRejectModal, setShowRejectModal] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log("서명 요청 정보:", signing);
     if (!signing.documentId) {
       alert("유효한 문서 정보가 없습니다. 이메일을 먼저 인증해주세요.");
       navigate("/");
@@ -27,7 +30,7 @@ const PreviewPage = () => {
 
   const handleReject = () => {
     setRejectReason("");
-    setShowModal(true);
+    setShowRejectModal(true);
   };
 
   const handleConfirmReject = () => {
@@ -39,7 +42,7 @@ const PreviewPage = () => {
     ApiService.rejectDocument(signing.documentId, rejectReason, signing.token, signing.signerEmail)
       .then(() => {
         alert("요청이 거절되었습니다.");
-        setShowModal(false);
+        setShowRejectModal(false);
         navigate("/");
       })
       .catch((error) => {
@@ -48,51 +51,103 @@ const PreviewPage = () => {
       });
   };
 
+  const handleSaveSignature = async (imageData) => {
+    const updatedFields = signing.signatureFields.map((field) =>
+      field.type === 0 ? { ...field, image: imageData } : field
+    );
+    setSigning((prev) => ({ ...prev, signatureFields: updatedFields }));
+    setShowPopup(false);
+  };
+
+  const handleSubmitSignature = async () => {
+    setLoading(true);
+    try {
+      const imageField = signing.signatureFields.find((field) => field.type === 0 && field.image);
+      let fileName = null;
+
+      if (imageField) {
+        const blob = await fetch(imageField.image).then((res) => res.blob());
+        fileName = await ApiService.uploadSignatureFile(blob, signing.signerEmail);
+      }
+
+      await ApiService.saveSignatures(signing.documentId, {
+        email: signing.signerEmail,
+        name: signing.signerName,
+        signatureFields: signing.signatureFields.map((field) => ({
+          signerEmail: signing.signerEmail,
+          type: field.type,
+          width: field.width,
+          height: field.height,
+          position: field.position,
+          imageName: field.type === 0 ? fileName : null,
+          textData: field.textData || null,
+        })),
+      });
+
+      alert("서명이 완료되었습니다.");
+      navigate("/sign-complete");
+    } catch (error) {
+      alert("서명 처리 중 오류 발생: " + error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isAllSigned = signing.signatureFields?.every((field) => field.image || field.textData);
+
   return (
     <MainContainer>
       <ContentWrapper>
         <Sidebar>
           <InfoSection>
-            <InfoItem>
-              <Label>작업 요청자:</Label>
-              <Value>{signing.requesterName || "알 수 없음"}</Value>
-            </InfoItem>
-            <InfoItem>
-              <Label>작업명:</Label>
-              <Value>{signing.requestName || "알 수 없음"}</Value>
-            </InfoItem>
-            <InfoItem>
-              <Label>작업 요청 상세:</Label>
-              <Value>{signing.description || "알 수 없음"}</Value>
-            </InfoItem>
-            <InfoItem>
-              <Label>문서 이름:</Label>
-              <Value>{signing.documentName || "알 수 없음"}</Value>
-            </InfoItem>
-            <InfoItem>
-              <Label>서명자:</Label>
-              <Value>{signing.signerName || "알 수 없음"}</Value>
-            </InfoItem>
-            <InfoItem>
-              <Label>서명 상태:</Label>
-              <Value>{signing.isSigned ? "서명 완료" : "서명 대기중"}</Value>
-            </InfoItem>
+            <InfoItem><Label>작업 요청자:</Label><Value>{signing.requesterName}</Value></InfoItem>
+            <InfoItem><Label>작업명:</Label><Value>{signing.requestName}</Value></InfoItem>
+            <InfoItem><Label>작업 요청 상세:</Label><Value>{signing.description}</Value></InfoItem>
+            <InfoItem><Label>문서 이름:</Label><Value>{signing.documentName}</Value></InfoItem>
+            <InfoItem><Label>서명자:</Label><Value>{signing.signerName}</Value></InfoItem>
+            <InfoItem><Label>서명 상태:</Label><Value>{signing.isSigned ? "서명 완료" : "서명 대기중"}</Value></InfoItem>
           </InfoSection>
 
           <ButtonContainer>
-            {signing.isRejectable && (<RejectButton onClick={handleReject}>거절하기</RejectButton>)}
-            <NextButton onClick={() => navigate("/sign")}>서명하기</NextButton>
+            {signing.isRejectable && <RejectButton onClick={handleReject}>거절하기</RejectButton>}
+            <NextButton onClick={() => setShowPopup(true)}>
+              {isAllSigned ? "다시 서명하기" : "서명하기"}
+            </NextButton>
+            {isAllSigned && <NextButton onClick={() => setShowCompleteModal(true)}>서명 완료</NextButton>}
           </ButtonContainer>
         </Sidebar>
 
         <PDFWrapper>
           {signing.fileUrl && signing.signatureFields ? (
             <DocumentContainer>
-              <PDFViewer
-                pdfUrl={signing.fileUrl}
-                setCurrentPage={setCurrentPage}
-              />
-              <SignatureMarker currentPage={currentPage} />
+              <PDFViewer pdfUrl={signing.fileUrl} setCurrentPage={setCurrentPage} />
+              {signing.signatureFields
+                .filter((field) => field.position.pageNumber === currentPage)
+                .map((field, index) => (
+                  <div
+                    key={index}
+                    style={{
+                      position: "absolute",
+                      left: field.position.x,
+                      top: field.position.y,
+                      width: field.width,
+                      height: field.height,
+                      border: field.image ? "none" : "2px dashed black",
+                      backgroundColor: field.image ? "transparent" : "#f8f9fa50",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {field.image && (
+                      <img
+                        src={field.image}
+                        alt="서명"
+                        style={{ width: "100%", height: "100%", objectFit: "contain", border: "2px solid black" }}
+                      />
+                    )}
+                  </div>
+              ))}
             </DocumentContainer>
           ) : (
             <LoadingMessage>문서 및 서명 정보를 불러오는 중...</LoadingMessage>
@@ -100,13 +155,31 @@ const PreviewPage = () => {
         </PDFWrapper>
       </ContentWrapper>
 
+      {showPopup && (
+        <SignaturePopup
+          field={signing.signatureFields[0]}
+          fieldIndex={0}
+          onClose={() => setShowPopup(false)}
+          onSave={handleSaveSignature}
+          applyToAll={true}
+        />
+      )}
+
+      <CompleteModal
+        open={showCompleteModal}
+        onClose={() => setShowCompleteModal(false)}
+        onConfirm={handleSubmitSignature}
+        loading={loading}
+        type="sign"
+      />
+
       <RejectModal
-        isVisible={showModal}
-        onClose={() => setShowModal(false)}
+        isVisible={showRejectModal}
+        onClose={() => setShowRejectModal(false)}
         onConfirm={handleConfirmReject}
         rejectReason={rejectReason}
         setRejectReason={setRejectReason}
-        type={"reject"}
+        type="reject"
       />
     </MainContainer>
   );
@@ -181,12 +254,15 @@ const LoadingMessage = styled.p`
 const ButtonContainer = styled.div`
   margin-top: 20px;
   text-align: center;
+  gap: 10px;
+  display: flex;
+  justify-content: center;
+  flex-direction: column-reverse;
 `;
 
 const NextButton = styled(ButtonBase)`
   background-color: #03A3FF;
   color: white;
-  margin-left: 10px;
   &:hover {
     background-color: rgba(3, 163, 255, 0.66);
   }

--- a/src/components/AllocatePage/CompleteModal.js
+++ b/src/components/AllocatePage/CompleteModal.js
@@ -5,12 +5,24 @@ import { BeatLoader } from "react-spinners";
 import { useRecoilValue } from 'recoil';
 import { taskState } from '../../recoil/atom/taskState';
 
-const CompleteModal = ({ open, onClose, onConfirm, loading }) => {
+const CompleteModal = ({ open, onClose, onConfirm, loading, type}) => {
   const document = useRecoilValue(taskState);
 
   const handleConfirm = async () => {
     await onConfirm(); // 상위에서 비동기 처리, 로딩은 상위가 관리
   };
+
+  const confirmMessage =
+    type === "sign"
+      ? "서명을 완료하시겠습니까?"
+      : document.type === 1
+        ? "검토 요청을 보내시겠습니까?"
+        : "요청을 완료하시겠습니까?";
+
+  const warningText =
+    type === "sign"
+      ? "*서명을 완료하시면 취소는 불가합니다."
+      : "*요청을 보내시면 수정이 불가합니다.";
 
   return (
     <>
@@ -33,7 +45,7 @@ const CompleteModal = ({ open, onClose, onConfirm, loading }) => {
           }}
         >
           {/* 근무일지 안내 (type 1일 때) */}
-          {document.type === 1 && (
+          {document.type === 1 && type !== "complete" && (
             <>
               <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 'bold' }}>
                 📝 근무일지 작성 시 확인사항
@@ -47,14 +59,14 @@ const CompleteModal = ({ open, onClose, onConfirm, loading }) => {
             </>
           )}
 
-          {/* 공통 경고 문구 */}
-          <Typography variant="caption" sx={{ color: 'red', display: 'block', mb: 1 }}>
-            *요청을 보내시면 수정이 불가합니다.
-          </Typography>
-
           {/* 확인 질문 */}
           <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
-            {document.type === 1 ? "검토 요청을 보내시겠습니까?" : "요청을 완료하시겠습니까?"}
+            {confirmMessage}
+          </Typography>
+
+          {/* 공통 경고 문구 */}
+          <Typography variant="caption" sx={{ color: 'red', display: 'block', mb: 1 }}>
+            {warningText}
           </Typography>
 
           {/* 버튼 */}

--- a/src/components/SignPage/PDFViewer.js
+++ b/src/components/SignPage/PDFViewer.js
@@ -1,27 +1,59 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Document, Page, pdfjs } from "react-pdf";
 import PagingControl from "../PagingControl";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
-function PDFViewer({ pdfUrl, setCurrentPage }) {
-  const [totalPages, setTotalPages] = useState(0);
+function PDFViewer({ pdfUrl, setCurrentPage, onScaleChange }) {
+  const containerRef = useRef(null);
   const [pageNum, setPageNum] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [scale, setScale] = useState(1);
+  const [containerWidth, setContainerWidth] = useState(800); // ✅ 실제 PDF 표시 너비 상태
+
+  useEffect(() => {
+    const updateDimensions = (width) => {
+      const newScale = width / 800;
+      setContainerWidth(width);
+      setScale(newScale);
+      onScaleChange?.(newScale);
+    };
+
+    const observer = new ResizeObserver(([entry]) => {
+      const newWidth = entry.contentRect.width;
+      updateDimensions(newWidth);
+    });
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+      updateDimensions(containerRef.current.offsetWidth);
+    }
+  
+    return () => observer.disconnect();
+  }, [onScaleChange]);
 
   const handlePageChange = (newPage) => {
     setPageNum(newPage);
-    setCurrentPage(newPage); // 현재 페이지 상태 업데이트
-    console.log("현재 페이지:", newPage);
+    setCurrentPage?.(newPage);
   };
 
   return (
     <>
-      <div style={{ position: "relative", width: "802px", margin: "0 auto", border: "1px solid #999"}}>
+      <div
+        ref={containerRef}
+        style={{
+          width: "100%",
+          margin: "0 auto",
+          position: "relative",
+        }}
+      >
         <Document
           file={pdfUrl}
-          onLoadSuccess={(pdf) => setTotalPages(pdf.numPages)}
+          onLoadSuccess={(pdf) => {
+            setTotalPages(pdf.numPages);
+          }}
         >
-          <Page pageNumber={pageNum} width={800} />
+          <Page pageNumber={pageNum} width={containerWidth} />
         </Document>
       </div>
       <PagingControl pageNum={pageNum} setPageNum={handlePageChange} totalPages={totalPages} />

--- a/src/components/SignPage/SignatureOverlay.js
+++ b/src/components/SignPage/SignatureOverlay.js
@@ -1,120 +1,47 @@
-// SignatureOverlay.js
-import { useEffect, useState } from "react";
-import { useRecoilState } from "recoil";
+// components/SignPage/SignatureOverlay.js
+import React from "react";
+import { useRecoilValue } from "recoil";
+import styled from "styled-components";
 import { signingState } from "../../recoil/atom/signingState";
-import DraggableSignature from "../DraggableSignature";
-import SignaturePopup from "./SignaturePopup";
 
-const SignatureOverlay = ({currentPage}) => {
-  const [signing, setSigning] = useRecoilState(signingState);
-  const [selectedField, setSelectedField] = useState(null);
-  const [signatureURL, setSignatureURL] = useState(null);
-  const [hoveredField, setHoveredField] = useState(null);
-
-  useEffect(() => {console.log(currentPage);console.log(signing);}, [currentPage,signing]);
-
-  // 서명 입력 팝업 열기
-  const openPopup = (fieldIndex) => {
-    setSelectedField(fieldIndex);
-  };
-
-  // 서명 입력 팝업 닫기
-  const closePopup = () => {
-    setSelectedField(null);
-  };
-
-  // 서명 삭제하기 (서명 위치는 유지)
-  const handleDeleteSignature = (index) => {
-    setSigning((prev) => ({
-      ...prev,
-      signatureFields: prev.signatureFields.map((field, i) =>
-        i === index ? { ...field, image: null } : field
-      ),
-    }));
-  };
+const SignatureOverlay = ({ currentPage, scale }) => {
+  const signing = useRecoilValue(signingState);
 
   return (
-    <div>
+    <>
       {signing.signatureFields
-        .filter((field) => field.position.pageNumber === currentPage) // ✅ 현재 페이지에 해당하는 서명 필드만 표시
-        .map((field, index) =>(
-        <div
-          key={index}
-          style={{
-            position: "absolute",
-            left: field.position.x,
-            top: field.position.y,
-            width: field.width,
-            height: field.height,
-            border: field.image ? "none" : "2px dashed black",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            cursor: "pointer",
-            backgroundColor: field.image ? "transparent" : "#f8f9fa50", // 이미지가 있으면 투명, 없으면 반투명 배경
-          }}
-          onClick={() => openPopup(index)}
-          onMouseEnter={() => setHoveredField(index)}
-          onMouseLeave={() => setHoveredField(null)}
-        >
-          {field.type === 0 && field.image && (
-            <img 
-              src={field.image} 
-              alt="서명" 
-              style={{ 
-                width: "100%", 
-                height: "100%",
-                objectFit: "contain",
-                border: "2px solid black",
-              }} 
-            />
-          )}
-          {field.type === 1 && field.text && (
-            <span style={{ fontSize: "16px", fontWeight: "bold" }}>{field.text}</span>
-          )}
-          {hoveredField === index && field.image && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                handleDeleteSignature(index);
-              }}
-              style={{
-                position: "absolute",
-                top: "-10px",
-                right: "-10px",
-                backgroundColor: "red",
-                color: "white",
-                border: "none",
-                padding: "5px 10px",
-                cursor: "pointer",
-                fontSize: "12px",
-                borderRadius: "5px",
-              }}
-            >
-              삭제
-            </button>
-          )}
-        </div>
-      ))}
-
-      {/* 드래그 가능한 서명 */}
-      {signatureURL && (
-        <DraggableSignature
-          url={signatureURL}
-          onCancel={() => setSignatureURL(null)}
-        />
-      )}
-
-      {/* 서명 입력 팝업 */}
-      {selectedField !== null && (
-        <SignaturePopup
-          field={signing.signatureFields[selectedField]}
-          fieldIndex={selectedField}
-          onClose={closePopup}
-        />
-      )}
-    </div>
+        ?.filter((field) => field.position.pageNumber === currentPage)
+        .map((field, index) => (
+          <FieldBox
+            key={index}
+            style={{
+              left: `${field.position.x * scale}px`,
+              top: `${field.position.y * scale}px`,
+              width: `${field.width * scale}px`,
+              height: `${field.height * scale}px`,
+              border: field.image ? "none" : "2px dashed black",
+              backgroundColor: field.image ? "transparent" : "#f8f9fa50",
+            }}
+          >
+            {field.image && (
+              <img
+                src={field.image}
+                alt="서명"
+                style={{ width: "100%", height: "100%", objectFit: "contain", border: "2px solid black" }}
+              />
+            )}
+          </FieldBox>
+        ))}
+    </>
   );
 };
+
+const FieldBox = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+`;
 
 export default SignatureOverlay;

--- a/src/components/SignPage/SignaturePopup.js
+++ b/src/components/SignPage/SignaturePopup.js
@@ -1,77 +1,56 @@
-// SignaturePopup.js
-
 import { useRef } from "react";
-
 import SignatureCanvas from "react-signature-canvas";
-import { useSetRecoilState } from "recoil";
-import { signingState } from "../../recoil/atom/signingState";
 import { BigButton } from "../BigButton";
 
-const SignaturePopup = ({ field, fieldIndex, onClose }) => {
-  const setSigning = useSetRecoilState(signingState);
+const SignaturePopup = ({ field, fieldIndex, onClose, onSave, applyToAll = false }) => {
   const sigCanvas = useRef(null);
 
-  // 서명 저장 (캔버스에서 이미지로 변환, 배경을 투명하게 처리)
+  // 서명 저장
   const handleSave = () => {
     if (sigCanvas.current) {
       const canvas = sigCanvas.current.getCanvas();
       const signatureData = createTransparentSignature(canvas);
 
-      setSigning((prev) => ({
-        ...prev,
-        signatureFields: prev.signatureFields.map((field) => 
-          field.type === 0 // ✅ 서명(type 0) 필드에만 서명 이미지 업데이트
-            ? { ...field, image: signatureData }
-            : field
-        ),
-      }));
-    }
-    onClose();
-  };
-
-  // 서명의 배경을 투명하게 만드는 함수
-  const createTransparentSignature = (canvas) => {
-    // 원본 캔버스의 크기를 가져옴
-    const { width, height } = canvas;
-    
-    // 새 캔버스 생성
-    const tempCanvas = document.createElement('canvas');
-    tempCanvas.width = width;
-    tempCanvas.height = height;
-    const ctx = tempCanvas.getContext('2d');
-    
-    // 원본 캔버스의 이미지 데이터 가져오기
-    const imageData = canvas.getContext('2d').getImageData(0, 0, width, height);
-    const data = imageData.data;
-    
-    // 배경 색상을 투명하게 설정
-    for (let i = 0; i < data.length; i += 4) {
-      // 하얀색 배경인 경우 (R,G,B 모두 255 또는 매우 높은 값)
-      if (data[i] > 240 && data[i+1] > 240 && data[i+2] > 240) {
-        // 완전히 투명하게 설정
-        data[i+3] = 0;
+      if (onSave) {
+        onSave(signatureData); // PreviewPage에서 전체 적용 또는 단일 적용 처리
       }
+
+      onClose();
     }
-    
-    // 수정된 이미지 데이터를 새 캔버스에 그리기
-    ctx.putImageData(imageData, 0, 0);
-    
-    // 투명 배경으로 된 PNG 이미지로 변환
-    return tempCanvas.toDataURL('image/png');
   };
 
-  // 서명 초기화
+  // 서명 캔버스 초기화
   const handleClear = () => {
     if (sigCanvas.current) {
       sigCanvas.current.clear();
     }
   };
 
+  // 하얀 배경을 투명하게 처리한 서명 이미지 생성
+  const createTransparentSignature = (canvas) => {
+    const { width, height } = canvas;
+    const tempCanvas = document.createElement("canvas");
+    tempCanvas.width = width;
+    tempCanvas.height = height;
+    const ctx = tempCanvas.getContext("2d");
+
+    const imageData = canvas.getContext("2d").getImageData(0, 0, width, height);
+    const data = imageData.data;
+
+    for (let i = 0; i < data.length; i += 4) {
+      if (data[i] > 240 && data[i + 1] > 240 && data[i + 2] > 240) {
+        data[i + 3] = 0; // 투명화
+      }
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+    return tempCanvas.toDataURL("image/png");
+  };
+
   return (
     <div style={popupStyle}>
       <h3>서명 입력</h3>
 
-      {/* 서명 캔버스 */}
       <SignatureCanvas
         ref={sigCanvas}
         penColor="black"
@@ -83,7 +62,6 @@ const SignaturePopup = ({ field, fieldIndex, onClose }) => {
         }}
       />
 
-      {/* 버튼 그룹 */}
       <div style={{ marginTop: 10, display: "flex", justifyContent: "center" }}>
         <BigButton marginRight={8} title="초기화" onClick={handleClear} />
         <BigButton marginRight={8} title="저장" onClick={handleSave} />
@@ -93,7 +71,6 @@ const SignaturePopup = ({ field, fieldIndex, onClose }) => {
   );
 };
 
-// 팝업 스타일
 const popupStyle = {
   position: "fixed",
   top: "50%",
@@ -107,7 +84,6 @@ const popupStyle = {
   borderRadius: "8px",
 };
 
-// 서명 캔버스 스타일
 const signatureCanvasStyle = {
   border: "1px solid #000",
   borderRadius: "8px",


### PR DESCRIPTION
- 미리보기 페이지에서 서명하기 버튼 클릭시 서명캔버스가 나오고 서명후 사이드바의 서명완료 버튼 클릭으로 서명을완료하도록 수정
- 서명 완료시 확인 모달창이 뜨고 확인시 모달창 이후 얼러트 창이 추가
- 서명 미리보기 페이지에서 문서와 서명 구역 반응형 추가