### PR TITLE
[CHORE] 크롬 번역을 위해 반려 -> 반려됨으로 변경, 디테일 페이지에서 상태에 따라 사유 표기 수정

### DIFF
--- a/src/Pages/AddSignerPage.js
+++ b/src/Pages/AddSignerPage.js
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IoClose } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 import { signerState } from "../recoil/atom/signerState";
 import { taskState } from "../recoil/atom/taskState";
-import { ButtonContainer, Container as BaseContainer, GrayButton, MainArea, NextButton, StyledBody } from "../styles/CommonStyles";
+import { Container as BaseContainer, ButtonContainer, GrayButton, MainArea, NextButton, StyledBody } from "../styles/CommonStyles";
 import ApiService from "../utils/ApiService";
 
 // BaseContainer를 흰 배경으로 덮는 새로운 Container
@@ -29,7 +29,7 @@ const AddSignerPage = () => {
   const [focusTarget, setFocusTarget] = useState("name"); // "name" or "email"
   const [showManualAddInputs, setShowManualAddInputs] = useState(false);
   const autocompleteRef = useRef(null);
-
+  const itemRefs = useRef([]);
   // 디바운싱
   const [debouncedName, setDebouncedName] = useState("");
   const [debouncedEmail, setDebouncedEmail] = useState("");
@@ -79,6 +79,22 @@ const AddSignerPage = () => {
     setActiveList(false);
     setHighlightedIndex(-1);
   };
+
+    // 🔄 검색 결과가 바뀔 때 itemRefs 초기화
+  useEffect(() => {
+    itemRefs.current = [];
+  }, [activeResults]);
+
+  // 🔽 highlight 이동 시 스크롤 이동
+  useEffect(() => {
+    const el = itemRefs.current[highlightedIndex];
+    if (el) {
+      el.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth"
+      });
+    }
+  }, [highlightedIndex]);
 
   const handleKeyDown = (e) => {
     if (!activeResults.length) return;
@@ -171,10 +187,11 @@ const AddSignerPage = () => {
                     return (
                       <SearchItem
                         key={signer.email}
+                        ref={(el) => itemRefs.current[index] = el}
                         onClick={() => toggleSigner(signer)}
                         className={highlightedIndex === index ? "highlighted" : ""}
                       >
-                        <span>{signer.name} ({signer.email})</span>
+                        <span>{signer.name} {signer.position} ({signer.email})</span>
                         <span>{selected ? "✅" : "⬜"}</span>
                       </SearchItem>
                     );

--- a/src/Pages/DetailPage.js
+++ b/src/Pages/DetailPage.js
@@ -1,10 +1,10 @@
 import { Viewer, Worker } from '@react-pdf-viewer/core';
 import '@react-pdf-viewer/core/lib/styles/index.css';
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import ApiService from '../utils/ApiService';
 import { toolbarPlugin } from '@react-pdf-viewer/toolbar';
 import '@react-pdf-viewer/toolbar/lib/styles/index.css';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import ApiService from '../utils/ApiService';
 
 const pdfjsWorkerUrl = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js';
 
@@ -81,7 +81,8 @@ const DetailPage = () => {
                         <div style={{marginTop: "6px"}}>
                             상태: <span className={getStatusClass(documentInfo.status)}>{getStatusLabel(documentInfo.status)}</span>
                         </div>
-                        <p><strong>취소 사유:</strong> {documentInfo.rejectReason}</p>
+                        {documentInfo.status == 3 ? (<p><strong>취소 사유:</strong> {documentInfo.rejectReason}</p>) : null}
+                        {documentInfo.status == 2 || documentInfo.status == 6 ? (<p><strong>반려 사유:</strong> {documentInfo.reviewRejectReason}</p>) : null}
                         <p><strong>서명 생성 시간:</strong> {new Date(documentInfo.createdAt).toLocaleString()}</p>
                         <p><strong>파일명:</strong> {documentInfo.fileName}</p>
                         <p><strong>작업명:</strong> {documentInfo.requestName}</p>

--- a/src/Pages/LandingPage.js
+++ b/src/Pages/LandingPage.js
@@ -1,141 +1,5 @@
-// import React, { useEffect } from "react";
-// import { Link } from "react-router-dom";
-// import { useRecoilValue } from "recoil";
-// import styled from "styled-components";
-// import HisnetLoginButton from "../components/HisnetLoginButton";
-// import { loginMemberState } from "../recoil/atom/loginMemberState";
-// import landingpic from "../asset/landingpic.png"; // 이미지 import
-
-// function SideBar() {
-//   const loginMember = useRecoilValue(loginMemberState);
-
-//   useEffect(() => {
-//     //console.log("loginMember", loginMember);
-//   }, [loginMember]);
-
-//   return (
-//     <PageContainer>
-//       <LeftPane>
-//         <Logo>HiSign</Logo>
-//         <Title>
-//           쉽고 빠르게
-//           <br />안전한 전자서명 솔루션
-//         </Title>
-//         {loginMember.unique_id ? (
-//           <ActionButton to="/tasksetup">서명 요청</ActionButton>
-//         ) : (
-//           <HisnetLoginButtonStyled>히즈넷으로 로그인</HisnetLoginButtonStyled>
-//         )}
-//       </LeftPane>
-//       <RightPane>
-//         <ImageContainer>
-//           <StyledImage src={landingpic} alt="랜딩페이지 사진" />
-//         </ImageContainer>
-//       </RightPane>
-//     </PageContainer>
-//   );
-// }
-
-// export default SideBar;
-
-
-// // Styled Components
-
-
-// const PageContainer = styled.div`
-//   display: flex;
-//   min-height: 100vh;
-//   @media (max-width: 768px) {
-//     flex-direction: column;
-//   }
-// `;
-
-// const LeftPane = styled.div`
-//   flex: 1;
-//   padding: 60px;
-//   display: flex;
-//   flex-direction: column;
-//   justify-content: center;
-//   gap: 24px;
-//   @media (max-width: 768px) {
-//     padding: 40px 20px;
-//     align-items: center;
-//     text-align: center;
-//   }
-// `;
-
-
-
-// const Logo = styled.h2`
-//   font-size: 1rem;
-//   letter-spacing: 2px;
-//   color: #888;
-//   margin: 0;
-// `;
-
-// const Title = styled.h1`
-//   font-size: 3rem;
-//   line-height: 1.2;
-//   margin: 0;
-//   @media (max-width: 768px) {
-//     font-size: 2rem;
-//   }
-// `;
-
-// const ActionButton = styled(Link)`
-//   display: inline-block;
-//   margin-top: 16px;
-//   padding: 10px 24px;
-//   background-color: #000;
-//   color: #fff;
-//   text-decoration: none;
-//   font-weight: 500;
-//   border-radius: 4px;
-//   font-size: 0.95rem;
-// `;
-
-
-// const HisnetLoginButtonStyled = styled(HisnetLoginButton)`
-// padding: 10px 24px;
-// font-size: 0.95rem;
-// border-radius: 6px;
-// font-weight: 500;
-// `;
-
-
-
-
-// const RightPane = styled.div`
-//   flex: 1;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   background: #f0f0f0;
-//   padding: 0;
-
-//   @media (max-width: 768px) {
-//     height: 250px; /* 모바일에서는 높이 고정 */
-//   }
-// `;
-
-// const ImageContainer = styled.div`
-//   width: 100%;
-//   height: 100%;
-// `;
-
-// const StyledImage = styled.img`
-//   width: 100%;
-//   height: 100%;
-//   object-fit: cover;
-
-//   @media (max-width: 768px) {
-//     object-fit: contain;
-//   }
-// `;
-
-
-import React, { useEffect } from "react";
-import { Link } from "react-router-dom";
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 import landingpic from "../asset/landingpic.png"; // 이미지 import
@@ -144,9 +8,13 @@ import { loginMemberState } from "../recoil/atom/loginMemberState";
 
 function SideBar() {
   const loginMember = useRecoilValue(loginMemberState);
+  const navigate = useNavigate();
 
   useEffect(() => {
-    //console.log("loginMember", loginMember);
+    if (loginMember.uniqueId) {
+      // 로그인된 상태라면 대시보드로 이동
+      navigate("/dashboard");
+    }
   }, [loginMember]);
 
   return (
@@ -157,7 +25,7 @@ function SideBar() {
           쉽고 빠르게
           <br />안전한 전자서명 솔루션
         </Title>
-        {loginMember.unique_id ? (
+        {loginMember.uniqueId ? (
           <ActionButton to="/tasksetup">서명 요청</ActionButton>
         ) : (
           <HisnetLoginButtonWrapper>

--- a/src/Pages/ReceiveListPage.js
+++ b/src/Pages/ReceiveListPage.js
@@ -7,7 +7,7 @@ import ViewListIcon from "@mui/icons-material/ViewList";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import { Pagination } from "@mui/material";
 import moment from "moment";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Dropdown } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { useRecoilState } from "recoil";
@@ -62,10 +62,10 @@ const ReceivedDocuments = () => {
         const statusLabels = {
             0: "서명중",
             1: "완료",
-            2: "반려",
+            2: "반려됨",
             3: "취소",
             4: "만료",
-            6: "반려",
+            6: "반려됨",
             7: "검토중",
         };
         return statusLabels[status] || "알 수 없음";

--- a/src/Pages/RequestListPage.js
+++ b/src/Pages/RequestListPage.js
@@ -7,7 +7,7 @@ import ViewListIcon from "@mui/icons-material/ViewList";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import { Box, Button, Modal, Pagination, Typography } from "@mui/material";
 import moment from "moment/moment";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Dropdown } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
@@ -87,10 +87,10 @@ const RequestedDocuments = () => {
         const statusLabels = {
             0: "서명중",
             1: "완료",
-            2: "반려",
+            2: "반려됨",
             3: "취소",
             4: "만료",
-            6: "반려",
+            6: "반려됨",
             7: "검토중",
         };
         return statusLabels[status] || "알 수 없음";

--- a/src/recoil/atom/loginMemberState.js
+++ b/src/recoil/atom/loginMemberState.js
@@ -3,7 +3,7 @@ import { atom } from 'recoil';
 export const loginMemberState = atom({
   key: 'loginMemberState',
   default: {
-        uniqueid: null,
+        uniqueId: null,
         name: '',
         email: '',
         role: '',


### PR DESCRIPTION
- 리스트 페이지에서 상태 "반려" -> "반려됨" 으로 변경,( 다국어지원 대신 크롬의 번역 툴을 테스트하는데 "반려" -> companion으로 변역됨)
- 디테일 페이지에서 문서의 상태에 따라 취소, 반려 사유가 렌더링 되도록 수정 